### PR TITLE
Fixed Shop Bundle Time Type association and improved Shop notifications.

### DIFF
--- a/Public & Backend/Public/Constants/ConsumablesConstants.js
+++ b/Public & Backend/Public/Constants/ConsumablesConstants.js
@@ -12,6 +12,7 @@ export const CONSUMABLES_CURRENTLY_AVAILABLE_FIELD = "currentlyAvailable";
 export const CONSUMABLES_HIDDEN_FIELD = "hidden";
 export const CONSUMABLES_RELEASE_REFERENCE_FIELD = "releaseReference";
 export const CONSUMABLES_SOURCE_TYPE_REFERENCE_FIELD = "sourceTypeReference";
+export const CONSUMABLES_URL_FIELD = "link-consumables-itemName";
 
 // If we want to at-a-glance determine what type of consumable we have, we do an includes() check with these constants.
 export const CONSUMABLES_CHALLENGE_SWAP_PATH_CONTENTS = "rerollcurrency.json";


### PR DESCRIPTION
Weekly Bundles have been designated as "Indefinite" since Season 2 began. This updates the logic to assign an empty FlairText to the Weekly category, with explicit exceptions.

Shop notifications have long tried to pull people to the site, but they don't have very useful information at-a-glance. This update adds a list of items in the bundle to the Twitter and Discord notifications. Push notifications are unchanged.