### PR TITLE
Fixed setPaginationIndexFromSave()

### DIFF
--- a/Public & Backend/Public/Pagination.js
+++ b/Public & Backend/Public/Pagination.js
@@ -28,7 +28,7 @@ console.log("Pagination Key: " + paginationKey);
 
 export function setPaginationIndexFromSave() {
     let savedPage = session.getItem(paginationKey);
-    if (parseInt(savedPage) > 0)
+    if (savedPage && parseInt(savedPage) > 0)
     {
         $w("#pagination1").currentPage = parseInt(savedPage);
         $w("#dynamicDataset").loadPage(parseInt(savedPage))


### PR DESCRIPTION
There was a bug when savedPage was null. This checks for that condition and performs a default action if it is true.