### PR TITLE
Corrected an incorrect error message.

### DIFF
--- a/Public & Backend/Backend/MediaManagerFunctions.js
+++ b/Public & Backend/Backend/MediaManagerFunctions.js
@@ -45,7 +45,7 @@ export async function getETag(headers, waypointPath, urlBase = ApiConstants.WAYP
 		});
 
 		request.on('error', error => {
-			console.error(`Got error: ${error.message} while fetching image at ${waypointPath}. Using placeholder image.`);
+			console.error(`Got error: ${error.message} while fetching image ETag at ${waypointPath}.`);
 			reject(error); // Assume the ETag doesn't match so we can try again.
 		});
 


### PR DESCRIPTION
There was an error message that suggested a Placeholder image would be used instead of the image obtained from the URL, but this does not apply to the getETag function. I have removed the sentence indicating that the placeholder image would be used from this error message.