### PR TITLE
Fixed an issue with default cross-core items

### DIFF
--- a/Public & Backend/Backend/CustomizationAutomationFunctions.js
+++ b/Public & Backend/Backend/CustomizationAutomationFunctions.js
@@ -2155,7 +2155,7 @@ async function processItem(headers,
 	 */
 
 	// This helps us avoid processing duplicate items.
-	if (itemPathsProcessed.includes(itemWaypointPath)) {
+	if (itemPathsProcessed.includes(itemWaypointPath) && !("isDefault" in options && options.isDefault)) {
 		if (itemType == CustomizationConstants.ITEM_TYPES.attachment) {
 			// Ensure necessary options are provided.
 			if (!("attachmentArray" in options)) {
@@ -2185,8 +2185,9 @@ async function processItem(headers,
 
 		return 1;
 	}
-
-	itemPathsProcessed.push(itemWaypointPath);
+	else {
+		itemPathsProcessed.push(itemWaypointPath);
+	}
 
 	// Get the item.
 	let itemWaypointJson = await ApiFunctions.getCustomizationItem(headers, itemWaypointPath);


### PR DESCRIPTION
When Visors became cross-core on Tuesday, some of them flagged a change to their Default of Core field. The issue was due to the fact that we skip processing for items that show up repeatedly, which is true of all cross-core items, and some core-specific items (specifically Kit items). We added some logic to ensure that items marked as defaults for a core are reprocessed, which will add the necessary Default of Core value to the item when relevant.