### PR TITLE
Fixed a formatting bug with autocomplete

### DIFF
--- a/Page Code/Main Pages/Customization Search Results.js
+++ b/Page Code/Main Pages/Customization Search Results.js
@@ -242,6 +242,7 @@ $w.onReady(async function () {
 
 	$w("#customizationSearchInput").onKeyPress(event => {
 		if(event.key == "Enter") {
+			$w("#autocompleteRepeater").data = [];
 			performSearch();
 		} else {
 			if (quickDebounceTimer) {
@@ -309,6 +310,7 @@ $w.onReady(async function () {
 
 	$w("#customizationSearchBar").onKeyPress(event => {
 		if(event.key == "Enter") {
+			$w("#globalAutocompleteRepeater").data = [];
 			performSearch(true); // We want to copy the value to the primary input box before we search.
 		}
 		else {


### PR DESCRIPTION
When pressing Enter on the main search page, the autocomplete repeater wasn't being cleared, so it would disfigure the rest of the page until a new search began. This change clears the relevant repeaters when a search is performed.